### PR TITLE
Fixes autocomplete text color when disabled

### DIFF
--- a/frontend/src/components/TuningIndividualString.css
+++ b/frontend/src/components/TuningIndividualString.css
@@ -47,3 +47,53 @@
   .individual-string-tuning-autocomplete .MuiAutocomplete-clearIndicator:hover {
     color: #aaaaaa;
   }
+
+  /* Disabled input text color */
+  .individual-string-tuning-autocomplete .MuiInputBase-input.Mui-disabled {
+    color: #b0b0b0;
+  }
+
+  /* Disabled input border color */
+  .individual-string-tuning-autocomplete .MuiOutlinedInput-root.Mui-disabled .MuiOutlinedInput-notchedOutline {
+    border-color: #b0b0b0;
+  }
+
+  /* Disabled popup indicator color */
+  .individual-string-tuning-autocomplete .MuiAutocomplete-popupIndicator.Mui-disabled {
+    color: #b0b0b0;
+  }
+
+  /* Disabled clear indicator color */
+  .individual-string-tuning-autocomplete .MuiAutocomplete-clearIndicator.Mui-disabled {
+    color: #b0b0b0;
+  }
+
+  /* Disabled clear indicator hover color */
+  .individual-string-tuning-autocomplete .MuiAutocomplete-clearIndicator.Mui-disabled:hover {
+    color: #a0a0a0;
+  }
+
+  /* Disabled focused input border color */
+  .individual-string-tuning-autocomplete .MuiOutlinedInput-root.Mui-focused.Mui-disabled .MuiOutlinedInput-notchedOutline {
+    border-color: #b0b0b0;
+  }
+
+  /* Disabled autocomplete background color */
+  .individual-string-tuning-autocomplete .MuiAutocomplete-root.Mui-disabled {
+    background-color: #b0b0b0;
+  }
+
+  /* Disabled form label color */
+  .individual-string-tuning-autocomplete .MuiFormLabel.Mui-disabled {
+    color: #b0b0b0;
+  }
+
+  /* Disabled input label color */
+  .individual-string-tuning-autocomplete .MuiInputLabel-root.Mui-disabled {
+    color: #b0b0b0;
+  }
+
+  /* Disabled outlined input text opacity and color */
+  .individual-string-tuning-autocomplete .MuiOutlinedInput-input.Mui-disabled  {
+    -webkit-text-fill-color: unset;
+  }

--- a/frontend/src/components/TuningIndividualString.tsx
+++ b/frontend/src/components/TuningIndividualString.tsx
@@ -38,36 +38,7 @@ const TuningIndividualStringAutocomplete: React.FC<TuningNoteProps> = ({
             value={noteState}
             options={noteOptions.map((option) => ({ value: option, label: option }))}
             renderInput={(params) => <TextField {...params} label={label} size="small" />}
-            onChange={handleChange}
-            sx={{
-                '& .MuiInputBase-input.Mui-disabled': {
-                    color: '#b0b0b0',
-                },
-                '& .MuiOutlinedInput-root.Mui-disabled .MuiOutlinedInput-notchedOutline': {
-                    borderColor: '#b0b0b0',
-                },
-                '& .MuiAutocomplete-popupIndicator.Mui-disabled': {
-                    color: '#b0b0b0',
-                },
-                '& .MuiAutocomplete-clearIndicator.Mui-disabled': {
-                    color: '#b0b0b0',
-                },
-                '& .MuiAutocomplete-clearIndicator.Mui-disabled:hover': {
-                    color: '#a0a0a0',
-                },
-                '& .MuiOutlinedInput-root.Mui-focused.Mui-disabled .MuiOutlinedInput-notchedOutline': {
-                    borderColor: '#b0b0b0',
-                },
-                '& .MuiAutocomplete-root.Mui-disabled': {
-                    backgroundColor: '#b0b0b0',
-                },
-                '& .MuiFormLabel.Mui-disabled': {
-                    color: '#b0b0b0',
-                },
-                '& .MuiInputLabel-root.Mui-disabled': {
-                    color: '#b0b0b0',
-                },
-            }}                                                                              
+            onChange={handleChange}                                                                              
         />
     );
 };


### PR DESCRIPTION
I just cleaned up the CSS classes in the tsx file and added this class to them so the text would not be black anymore.

```css
  /* Disabled outlined input text opacity and color */
  .individual-string-tuning-autocomplete .MuiOutlinedInput-input.Mui-disabled  {
    -webkit-text-fill-color: unset;
  }
```

## Screenshot

<img width="1214" alt="Screenshot 2025-01-10 at 7 21 19 PM" src="https://github.com/user-attachments/assets/ea24bb84-01f9-4e2b-8141-5d861b097b20" />
